### PR TITLE
Remove unused pandas dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,3 @@ scikit-learn>=1.3.0
 
 # Numerical computing
 numpy>=1.24.0
-
-# Data handling
-pandas>=2.0.0


### PR DESCRIPTION
## Summary
- Remove `pandas>=2.0.0` from `requirements.txt` since it is never imported or used in the codebase
- Reduces unnecessary install overhead for users

## Changes
- `requirements.txt`: removed `pandas>=2.0.0` entry

## Test plan
- [x] Verified `pandas` is not imported anywhere in `src/`
- [x] Unit tests pass (`python -m unittest tests.test_document_matcher -v`)

Closes #1