### PR TITLE
Simplify redundant corpus download check

### DIFF
--- a/src/corpus_loader.py
+++ b/src/corpus_loader.py
@@ -38,15 +38,9 @@ class CorpusLoader:
 
         Put this in a separate method so it's not cluttering up load_corpus()
         """
-        try:
-            # check if we already have it
-            nltk.data.find('corpora/reuters')
-        except LookupError:
-            # nope, need to download
-            print("Downloading Reuters corpus...")
-            print("(This only happens once - approximately 2MB download)")
-            nltk.download('reuters')
-            print("Download complete!")
+        # nltk.download() already checks if the corpus is present
+        # and skips the download if so, no manual check needed
+        nltk.download('reuters', quiet=True)
 
     def load_corpus(self) -> Tuple[List[str], List[str]]:
         """


### PR DESCRIPTION
## Summary
- Replace manual `nltk.data.find()` + `nltk.download()` two-step check with a single `nltk.download('reuters', quiet=True)` call
- `nltk.download()` already handles the "already present" case internally, making the manual check redundant

## Changes
- `src/corpus_loader.py`: simplified `download_reuters()` method (9 lines removed, 3 added)

## Test plan
- [x] Unit tests pass (`python -m unittest tests.test_document_matcher -v`)
- [x] Verified `nltk.download('reuters', quiet=True)` downloads when missing and silently skips when present

Closes #3