### PR TITLE
Fix main.py imports for all invocation methods

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,13 @@ This is the main program that the user runs. It handles:
 Usage: python main.py
 """
 
+import os
 import sys
+
+# ensure sibling modules are importable regardless of how the script is invoked
+# (e.g. python src/main.py, python -m src.main, or from a different working directory)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
 from corpus_loader import CorpusLoader
 from document_matcher import DocumentMatcher
 


### PR DESCRIPTION
## Summary
- Add the script's own directory to `sys.path` so sibling modules are always resolvable
- Fixes `ModuleNotFoundError` when running `python -m src.main` or invoking from a different working directory

## Changes
- `src/main.py`: added `sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))` before imports

## Test plan
- [x] Unit tests pass (`python -m unittest tests.test_document_matcher -v`)
- [x] `python src/main.py` — imports resolve correctly
- [x] `python -m src.main` — imports resolve correctly (was broken before)

Closes #7